### PR TITLE
fixing discord invite links to the standard vanity link

### DIFF
--- a/discordbot.js
+++ b/discordbot.js
@@ -1027,7 +1027,7 @@ exports.createDiscordClient = (web3, contracts, getStores, runSidechainTransacti
                               const balance = await contracts.FT.methods.balanceOf(address).call();
 
                               if (balance === "0") {
-                                message.channel.send('<@!' + userId + '> has ' + balance + ' SILK. Want to get some SILK? Ask the Webaverse team: https://discord.gg/HxdjCDyq58');
+                                message.channel.send('<@!' + userId + '> has ' + balance + ' SILK. Want to get some SILK? Ask the Webaverse team: https://discord.gg/webaverse');
                               } else {
                                 message.channel.send('<@!' + userId + '> has ' + balance + ' SILK.');
                               }
@@ -1047,7 +1047,7 @@ exports.createDiscordClient = (web3, contracts, getStores, runSidechainTransacti
                               const balance = await contracts.FT.methods.balanceOf(address).call();
 
                               if (balance === "0") {
-                                message.channel.send('<@!' + message.author.id + '> has ' + balance + ' SILK. Want to get some SILK? Ask the Webaverse team: https://discord.gg/HxdjCDyq58');
+                                message.channel.send('<@!' + message.author.id + '> has ' + balance + ' SILK. Want to get some SILK? Ask the Webaverse team: https://discord.gg/webaverse');
                               } else {
                                 message.channel.send('<@!' + message.author.id + '> has ' + balance + ' SILK.');
                               }
@@ -3186,7 +3186,7 @@ ${s.replace(/^\s*\S+\s*/, '')}
                                               } else {
                                                   const balance = await contracts.FT.methods.balanceOf(address).call();
                                                   if (balance < 10) {
-                                                      message.channel.send('<@!' + message.author.id + '>: mint transaction failed: you do not have enough SILK. Ask the Webaverse team for some! https://discord.gg/HxdjCDyq58');
+                                                      message.channel.send('<@!' + message.author.id + '>: mint transaction failed: you do not have enough SILK. Ask the Webaverse team for some! https://discord.gg/webaverse');
                                                   } else {
                                                       message.channel.send('<@!' + message.author.id + '>: mint transaction failed: this item has already been minted.');
                                                   }


### PR DESCRIPTION
The links in the messages to people with a zero balance were expired. I've replaced them with our standard https://discord.gg/webaverse links that also won't expire.